### PR TITLE
Fixes for using with GNOME 3.18

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -158,17 +158,13 @@ const WebSearchDialog = new Lang.Class({
 
         this.search_history = new HistoryManager.SearchHistoryManager();
 
-        this._search_table = new St.Table({
-            name: 'web_search_table'
+        this._search_table = new St.Widget({
+            name: 'web_search_table',
+            layout_manager: new Clutter.TableLayout()
         });
-        this._search_table.add(this.search_engine_label, {
-            row: 0,
-            col: 0
-        });
-        this._search_table.add(this.search_entry, {
-            row: 0,
-            col: 1
-        });
+        let search_table_layout = this._search_table.layout_manager;
+        search_table_layout.pack(this.search_engine_label, 0, 0);
+        search_table_layout.pack(this.search_entry, 1, 0);
         this._search_table.show();
 
         this.contentLayout.add(this._search_table);

--- a/helper.js
+++ b/helper.js
@@ -1,7 +1,6 @@
 const St = imports.gi.St;
 const Lang = imports.lang;
 const PopupMenu = imports.ui.popupMenu;
-const Animation = imports.ui.animation;
 const Params = imports.misc.params;
 const Tweener = imports.ui.tweener;
 const Soup = imports.gi.Soup;
@@ -29,13 +28,6 @@ const HelperSpinnerMenuItem = Lang.Class({
         });
         this._type = 'HELPER';
 
-        let spinner_icon = Gio.File.new_for_uri(
-            'resource:///org/gnome/shell/theme/process-working.svg'
-        );
-        let spinner = new Animation.AnimatedIcon(spinner_icon, 24);
-        spinner.actor.show();
-        spinner.play();
-
         let label = new St.Label({
             text: Utils.is_blank(text) ? 'Checking helper...' : text
         });
@@ -43,7 +35,6 @@ const HelperSpinnerMenuItem = Lang.Class({
         let box = new St.BoxLayout({
             style_class: 'helper-title'
         });
-        box.add(spinner.actor);
         box.add(label);
 
         this.actor.add_child(box);

--- a/helper.js
+++ b/helper.js
@@ -75,19 +75,16 @@ const DuckDuckGoHelperMenuItem = new Lang.Class({
         }
 
         let icon = this._get_icon(data.icon);
-        let table = new St.Table({
+        let table = new St.Widget({
             name: 'helper_table',
-            style_class: 'helper-box'
+            style_class: 'helper-box',
+            layout_manager: new Clutter.TableLayout()
         });
+        let table_layout = table.layout;
         let max_length = 80;
 
         if(icon) {
-            table.add(icon, {
-                row: 0,
-                col: 1,
-                x_fill: false,
-                y_fill: false
-            });
+            table_layout.pack(icon, 1, 0);
         }
         else {
             max_length = 110;
@@ -97,10 +94,7 @@ const DuckDuckGoHelperMenuItem = new Lang.Class({
         if(data.definition) {text += '<i>'+data.definition.trim()+'</i>\n';}
         if(data.abstract) {text += data.abstract.trim();}
         let label = this._get_label(text, 'helper-abstract', max_length);
-        table.add(label, {
-            row: 0,
-            col: 0
-        });
+        table_layoutpack(label, 0, 0);
 
         this.actor.add_child(table);
 

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
     "name": "Web Search Dialog",
     "shell-version": [
         "3.15.90",
-        "3.16"
+        "3.16",
+        "3.18"
     ],
     "url": "http://github.com/awamper/web-search-dialog",
     "uuid": "web_search_dialog@awamper.gmail.com",


### PR DESCRIPTION
Here are the fixes I needed to make in order to get the extension working with GNOME 3.18.

There's most likely a better way of handling the `process-working.svg` -> `classic-process-working.svg` name change than removing it altogether :-)