### PR TITLE
Remove reference to Shell.ActionMode.MESSAGE_TRAY

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1000,7 +1000,6 @@ const WebSearchDialog = new Lang.Class({
             this._settings,
             Meta.KeyBindingFlags.NONE,
             Shell.ActionMode.NORMAL |
-            Shell.ActionMode.MESSAGE_TRAY |
             Shell.ActionMode.OVERVIEW,
             Lang.bind(this, function() {
                 this.open()


### PR DESCRIPTION
This is no longer available in GNOME 3.24.